### PR TITLE
Setting the owner instance on new records.

### DIFF
--- a/lib/property_sets/active_record_extension.rb
+++ b/lib/property_sets/active_record_extension.rb
@@ -68,7 +68,11 @@ module PropertySets
             # The finder method which returns the property if present, otherwise a new instance with defaults
             define_method "lookup" do |arg|
               instance   = detect { |property| property.name.to_sym == arg.to_sym }
-              instance ||= @owner.send(association).build(:name => arg.to_s, :value => property_class.default(arg))
+              instance ||= build(:name => arg.to_s, :value => property_class.default(arg))
+
+              instance.send("#{owner_class_sym}=", @owner) if @owner.new_record?
+
+              instance
             end
 
             # This finder method returns the property if present,

--- a/test/test_property_sets.rb
+++ b/test/test_property_sets.rb
@@ -113,6 +113,14 @@ class TestPropertySets < ActiveSupport::TestCase
       assert record.account.id == @account.id
     end
 
+    should "reference the owner instance when constructing a new record ...on a new record" do
+      account = Account.new(:name => "New")
+      record  = account.settings.lookup(:baz)
+
+      assert record.new_record?
+      assert record.account == account
+    end
+
     context "validations" do
       should "add an error when violated" do
         @account.validations.validated = "hello"


### PR DESCRIPTION
Previously we were correctly referencing the owner instance when
looking up properties. e.g.: `model.properties.lookup(:foo)` would
set `foo.model` correctly.

This works because ActiveRecord's #build does this automatically for
us. `model.properties.build` stores `model_id` on the new property.

However, if model is a new record, ActiveRecord's #build can not
store the `model_id` on the new property because the model does not
have an id yet.

In this case, we're manually setting the model _object_ on the new
property instead of the model_id.
