### PR TITLE
Passing html_options to the template's select builder.

### DIFF
--- a/lib/property_sets/action_view_extension.rb
+++ b/lib/property_sets/action_view_extension.rb
@@ -36,25 +36,25 @@ module ActionView
           template.hidden_field(object_name, property, prepare_id_name(property, options))
         end
 
-        def select(property, choices, options = {})
+        def select(property, choices, options = {}, html_options = {})
           options = prepare_id_name(property, options)
           current_value = options[:object].send(property_set).send(property)
-          template.select("#{object_name}[#{property_set}]", property, choices, :selected => current_value)
+          template.select("#{object_name}[#{property_set}]", property, choices, { :selected => current_value }, html_options )
         end
 
         def prepare_id_name(property, options)
           throw "Invalid options type #{options.inspect}" unless options.is_a?(Hash)
 
-          instance = template.instance_variable_get("@#{object_name}")
+          options.clone.tap do |prepared_options|
+            instance = template.instance_variable_get("@#{object_name}")
 
-          throw "No @#{object_name} in scope" if instance.nil?
-          throw "The property_set_check_box only works on models with property set #{property_set}" unless instance.respond_to?(property_set)
+            throw "No @#{object_name} in scope" if instance.nil?
+            throw "The property_set_check_box only works on models with property set #{property_set}" unless instance.respond_to?(property_set)
 
-          options[:id]     ||= "#{object_name}_#{property_set}_#{property}"
-          options[:name]     = "#{object_name}[#{property_set}][#{property}]"
-          options[:object]   = instance
-
-          options
+            prepared_options[:id]     ||= "#{object_name}_#{property_set}_#{property}"
+            prepared_options[:name]     = "#{object_name}[#{property_set}][#{property}]"
+            prepared_options[:object]   = instance
+          end
         end
 
         def prepare_options(property, options, &block)

--- a/test/test_view_extensions.rb
+++ b/test/test_view_extensions.rb
@@ -110,21 +110,33 @@ class TestViewExtensions < ActiveSupport::TestCase
     end
 
     context "select" do
-      should "render a <select> with <option>s" do
+      setup do
         settings = stub(:count => "2")
         object   = stub()
-        object.expects(@association).returns(settings)
+        object.stubs(@association).returns(settings)
 
-        template = stub()
-        template.expects(:instance_variable_get).with("@object_name").returns(object)
+        @template = stub()
+        @template.expects(:instance_variable_get).with("@object_name").returns(object)
+      end
+
+      should "render a <select> with <option>s" do
 
         select_options = { :selected => "2" }
         select_choices = [["One", 1], ["Two", 2], ["Three", 3]]
-        html_options   = { :id => "foo", :name => "bar" }
-        template.expects(:select).with("object_name[settings]", :count, select_choices, select_options)
 
-        @proxy.stubs(:template).returns(template)
+        @template.expects(:select).with("object_name[settings]", :count, select_choices, select_options, {})
+        @proxy.stubs(:template).returns(@template)
         @proxy.select(:count, select_choices)
+      end
+
+      should "merge :html_options" do
+        select_options = { :selected => "2" }
+        select_choices = [["One", 1], ["Two", 2], ["Three", 3]]
+        html_options   = { :id => "foo", :name => "bar", :disabled => true }
+
+        @template.expects(:select).with("object_name[settings]", :count, select_choices, select_options, html_options)
+        @proxy.stubs(:template).returns(@template)
+        @proxy.select(:count, select_choices, select_options, html_options)
       end
     end
   end


### PR DESCRIPTION
This allows html options to be passed directly to the form builder.

It also modifies `#prepare_id_name` to returned a cloned version of the supplied options hash.

/cc @morten @hashwin
