### PR TITLE
implement association.save

### DIFF
--- a/lib/property_sets/active_record_extension.rb
+++ b/lib/property_sets/active_record_extension.rb
@@ -55,6 +55,14 @@ module PropertySets
             end
           end
 
+          def save(validations=true)
+            each { |p| p.save(validations) }
+          end
+
+          def save!(validations=true)
+            each { |p| p.save!(validations) }
+          end
+
           def protected?(arg)
             lookup(arg).protected?
           end

--- a/test/test_property_sets.rb
+++ b/test/test_property_sets.rb
@@ -236,6 +236,18 @@ class TestPropertySets < ActiveSupport::TestCase
       end
     end
 
+    context "save" do
+      should "call save on all dem records" do
+        @account.settings.foo = "1"
+        @account.settings.bar = "2"
+        @account.settings.save
+
+        @account.reload
+        assert_equal "1", @account.settings.foo
+        assert_equal "2", @account.settings.bar
+      end
+    end
+
     context "typed columns" do
       context "string data" do
         should "be writable and readable" do


### PR DESCRIPTION
In a bunch of places we're trying to save a setting or two without triggering a save of the main record. 

Thus far I've done:
account.settings.value = "foo"
account.settings.value_record.save

but that's ugly.  this adds:
account.settings.value = "foo"
account.settings.save
