### PR TITLE
allow pass-through to the property_set has_many call

### DIFF
--- a/lib/property_sets/active_record_extension.rb
+++ b/lib/property_sets/active_record_extension.rb
@@ -4,7 +4,7 @@ module PropertySets
   module ActiveRecordExtension
     module ClassMethods
 
-      def property_set(association, &block)
+      def property_set(association, options = {}, &block)
         unless include?(PropertySets::ActiveRecordExtension::InstanceMethods)
           self.send(:include, PropertySets::ActiveRecordExtension::InstanceMethods)
           cattr_accessor :property_set_index
@@ -17,7 +17,8 @@ module PropertySets
         property_class = PropertySets.ensure_property_set_class(association, self)
         property_class.instance_eval(&block)
 
-        has_many association, :class_name => property_class.name, :autosave => true, :dependent => :destroy do
+        hash_opts = {:class_name => property_class.name, :autosave => true, :dependent => :destroy}.merge(options)
+        has_many association, hash_opts do
 
           # Accepts a name value pair hash { :name => 'value', :pairs => true } and builds a property for each key
           def set(property_pairs, with_protection = false)

--- a/test/test_property_sets.rb
+++ b/test/test_property_sets.rb
@@ -15,7 +15,16 @@ class TestPropertySets < ActiveSupport::TestCase
     end
 
     should "register the property sets used on a class" do
-      assert_equal [ :settings, :texts, :validations, :typed_data ], Account.property_set_index
+      [ :settings, :texts, :validations, :typed_data ].each do |name|
+        assert Account.property_set_index.include?(name)
+      end
+    end
+
+    should "pass-through any options from the second parameter" do
+      Account.expects(:has_many).with { |association, h|
+        association == :foo && h[:conditions] == "bar"
+      }
+      Account.property_set(:foo, :conditions => "bar") {}
     end
 
     should "support protecting attributes" do


### PR DESCRIPTION
allow further configuration of the has_many association that we generate.
