### PR TITLE
require active_record where needed

### DIFF
--- a/lib/property_sets/active_record_extension.rb
+++ b/lib/property_sets/active_record_extension.rb
@@ -1,3 +1,4 @@
+require 'active_record'
 require 'property_sets/casting'
 
 module PropertySets


### PR DESCRIPTION
I was not able to use `bundle console` in my project without this change.
