### PR TITLE
Cast boolean values to 0/1 in hidden fields

### DIFF
--- a/lib/property_sets/action_view_extension.rb
+++ b/lib/property_sets/action_view_extension.rb
@@ -33,7 +33,11 @@ module ActionView
         end
 
         def hidden_field(property, options = {})
-          template.hidden_field(object_name, property, prepare_id_name(property, options))
+          options = prepare_id_name(property, options)
+          unless options.keys.include?(:value)
+            options[:value] = cast_boolean(options[:object].send(property_set).send(property)) 
+          end
+          template.hidden_field(object_name, property, options)
         end
 
         def select(property, choices, options = {}, html_options = {})
@@ -62,6 +66,17 @@ module ActionView
           options[:checked] = yield(options[:object].send(property_set))
           options
         end
+
+        private
+
+        def cast_boolean(value)
+          case value
+          when TrueClass  then '1'
+          when FalseClass then '0'
+          else value
+          end
+        end
+
       end
 
       def property_set(identifier)

--- a/test/test_view_extensions.rb
+++ b/test/test_view_extensions.rb
@@ -49,16 +49,44 @@ class TestViewExtensions < ActiveSupport::TestCase
     end
 
     context "#hidden_field" do
-      context "when called with a provided value" do
+      context "when the persisted value is not a boolean" do
         setup do
           settings = stub(@property => 'persisted value')
           @object.stubs(@property_set).returns(settings)
         end
 
-        should "build a hidden field with the provided value" do
-          expected_options = base_options.merge(:value => 'provided value')
+        should "build a hidden field with the persisted value" do
+          expected_options = base_options.merge(:value => 'persisted value')
           @template.expects(:hidden_field).with(@object_name, @property, expected_options)
-          @proxy.hidden_field(@property, {:value => 'provided value'})
+          @proxy.hidden_field(@property)
+        end
+
+        context "and a value is provided" do
+          should "build a hidden field with the provided value" do
+            expected_options = base_options.merge(:value => 'provided value')
+            @template.expects(:hidden_field).with(@object_name, @property, expected_options)
+            @proxy.hidden_field(@property, {:value => 'provided value'})
+          end
+        end
+      end
+
+      context "when the persisted value is a boolean" do
+        should "build a hidden field with cast boolean value if it is a boolean true" do
+          settings = stub(@property => true)
+          @object.stubs(@property_set).returns(settings)
+
+          expected_options = base_options.merge(:value => '1')
+          @template.expects(:hidden_field).with(@object_name, @property, expected_options)
+          @proxy.hidden_field(@property)
+        end
+
+        should "build a hidden field with cast boolean value if it is a boolean false" do
+          settings = stub(@property => false)
+          @object.stubs(@property_set).returns(settings)
+
+          expected_options = base_options.merge(:value => '0')
+          @template.expects(:hidden_field).with(@object_name, @property, expected_options)
+          @proxy.hidden_field(@property)
         end
       end
     end
@@ -78,7 +106,7 @@ class TestViewExtensions < ActiveSupport::TestCase
       end
     end
 
-    context "radio_button" do
+    context "#radio_button" do
       context "when called with checked true for a truth value" do
         setup do
           settings = stub(@property => 'hello')
@@ -93,7 +121,7 @@ class TestViewExtensions < ActiveSupport::TestCase
       end
     end
 
-    context "select" do
+    context "#select" do
       setup do
         settings = stub(:count => '2')
         @object.stubs(@property_set).returns(settings)


### PR DESCRIPTION
This allows a `hidden_field` tag to "just work" even when the value being persisted is a boolean.

Given:

``` ruby
property_set :settings do
  property :sso_agent_auth, :type => :boolean, :default => true
end
```

then the following:

```
<%= f.property_set(:settings).hidden_field :sso_agent_auth %>
```

yields:

```
<input id="account_settings_sso_agent_auth" name="account[settings][sso_agent_auth]" type="hidden" value="1">
```

@morten @staugaard @kbuckler 

cc/ @rapheld 
