### PR TITLE
Update radio_button helper to not cast to string before comparing values...

### DIFF
--- a/lib/property_sets/action_view_extension.rb
+++ b/lib/property_sets/action_view_extension.rb
@@ -22,7 +22,7 @@ module ActionView
 
         def radio_button(property, checked_value = "1", options = {})
           options = prepare_options(property, options) do |properties|
-            properties.send("#{property}") == checked_value.to_s
+            properties.send("#{property}") == checked_value
           end
           template.radio_button(object_name, property, checked_value, options)
         end

--- a/test/test_view_extensions.rb
+++ b/test/test_view_extensions.rb
@@ -128,6 +128,19 @@ class TestViewExtensions < ActiveSupport::TestCase
           @proxy.radio_button(@property, 'hello')
         end
       end
+
+      context "when called with a value of a different type" do
+        setup do
+          settings = stub(@property => '1')
+          @object.stubs(@property_set).returns(settings)
+        end
+
+        should "call with checked false" do
+          expected_options = base_options.merge(:checked => false)
+          @template.expects(:radio_button).with(@object_name, @property, 1, expected_options)
+          @proxy.radio_button(@property, 1)
+        end
+      end
     end
 
     context "#select" do


### PR DESCRIPTION
... when determining checked state

@morten @staugaard @kbuckler 

cc/ @craiglittle 
