### PR TITLE
Make property data access more flexible

### DIFF
--- a/lib/property_sets/property_set_model.rb
+++ b/lib/property_sets/property_set_model.rb
@@ -1,3 +1,5 @@
+require 'active_support'
+
 module PropertySets
   module PropertySetModel
     module InstanceMethods
@@ -89,7 +91,7 @@ module PropertySets
       end
 
       def property(key, options = nil)
-        @properties ||= {}
+        @properties ||= HashWithIndifferentAccess.new
         @properties[key] = options
       end
 

--- a/test/test_property_sets.rb
+++ b/test/test_property_sets.rb
@@ -62,6 +62,11 @@ class TestPropertySets < ActiveSupport::TestCase
       assert_equal 'skep', @account.settings.hep
     end
 
+    should "be flexible when fetching property data" do
+      assert_equal 'skep', @account.settings.default(:hep)
+      assert_equal 'skep', @account.settings.default('hep')
+    end
+
     context 'querying for a setting that does not exist' do
       setup do
         assert_equal([], @account.settings)


### PR DESCRIPTION
I've been running into situations where I've built up a key to look up dynamically and wanted to be able to pass the constructed string as a key to methods like `#default` without having to call `to_sym` on it first. I think this provides a slightly friendlier interface.

@morten @staugaard @kbuckler @rapheld 
