### PR TITLE
Typecast default value when fetching directly

### DIFF
--- a/lib/property_sets/active_record_extension.rb
+++ b/lib/property_sets/active_record_extension.rb
@@ -83,7 +83,7 @@ module PropertySets
           end
 
           def build_default(arg)
-            build(:name => arg.to_s, :value => default(arg))
+            build(:name => arg.to_s, :value => raw_default(arg))
           end
 
           def lookup_without_default(arg)
@@ -116,7 +116,7 @@ module PropertySets
               else
                 association_class = @reflection.klass
               end
-              association_class.new(:value => default(arg))
+              association_class.new(:value => raw_default(arg))
             end
             instance.value_serialized = property_serialized?(arg)
             instance

--- a/lib/property_sets/property_set_model.rb
+++ b/lib/property_sets/property_set_model.rb
@@ -100,6 +100,12 @@ module PropertySets
       end
 
       def default(key)
+        if @properties[key] && @properties[key].key?(:default)
+          PropertySets::Casting.read(type(key), @properties[key][:default])
+        end
+      end
+
+      def raw_default(key)
         @properties[key] && @properties[key].key?(:default) ? @properties[key][:default] : nil
       end
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -30,6 +30,12 @@ end
 ActiveSupport::TestCase.fixture_path = File.dirname(__FILE__) + "/fixtures/"
 $LOAD_PATH.unshift(ActiveSupport::TestCase.fixture_path)
 
+class ActsLikeAnInteger
+  def to_i
+    123
+  end
+end
+
 class Account < ActiveRecord::Base
   property_set :settings do
     property :foo
@@ -58,5 +64,6 @@ class Account < ActiveRecord::Base
     property :float_prop, :type => :float
     property :int_prop, :type => :integer
     property :serialized_prop, :type => :serialized
+    property :default_prop, :type => :integer, :default => ActsLikeAnInteger.new
   end
 end

--- a/test/test_property_sets.rb
+++ b/test/test_property_sets.rb
@@ -270,6 +270,11 @@ class TestPropertySets < ActiveSupport::TestCase
     end
 
     context "typed columns" do
+
+      should "typecast the default value" do
+        assert_equal 123, @account.typed_data.default(:default_prop)
+      end
+
       context "string data" do
         should "be writable and readable" do
           @account.typed_data.string_prop = "foo"


### PR DESCRIPTION
Given:

``` ruby
class ActsLikeAnInteger
  def to_i
    123
  end
end

class Account < ActiveRecord::Base
  property_set :settings do
    property :default_prop, :type => :integer, :default => ActsLikeAnInteger.new
  end
end
```

Currently, you get this behavior:

``` ruby
account.settings.default_prop           # => 123
account.settings.default(:default_prop) # => #<ActsLikeAnInteger:0x007fcab2945708>
```

With this change, you get this behavior:

``` ruby
account.settings.default_prop           # => 123
account.settings.default(:default_prop) # => 123
```

@kbuckler @morten @eac 
