### PR TITLE
Bug fix: Don't flatten serialized values

### DIFF
--- a/lib/property_sets/active_record_extension.rb
+++ b/lib/property_sets/active_record_extension.rb
@@ -30,8 +30,8 @@ module PropertySets
 
             property_pairs = property_keys.map do |name|
               value = lookup_value(association_class.type(name), name)
-              [name.to_s, value]
-            end.flatten
+              [name, value]
+            end.flatten(1)
             HashWithIndifferentAccess[*property_pairs]
           end
 

--- a/test/test_property_sets.rb
+++ b/test/test_property_sets.rb
@@ -176,6 +176,12 @@ class TestPropertySets < ActiveSupport::TestCase
       should "return a hash with values that can be fetched by string or symbol" do
         assert_equal "456", @account.settings.get(["baz"]).fetch(:baz)
       end
+
+      should "return serialized values" do
+        @account.typed_data.set(:serialized_prop => [1, 2])
+        assert @account.typed_data.lookup_without_default(:serialized_prop)
+        assert_equal({"serialized_prop" => [1, 2]}, @account.typed_data.get([:serialized_prop]))
+      end
     end
 
     context "#set" do


### PR DESCRIPTION
@zendesk/octo found this bug when I attempted to use the #get method in classic. 
