### PR TITLE
Allow the owner class to be customizable

### DIFF
--- a/lib/property_sets.rb
+++ b/lib/property_sets.rb
@@ -8,8 +8,8 @@ rescue LoadError
 end
 
 module PropertySets
-  def self.ensure_property_set_class(association, owner_class)
-    const_name = "#{owner_class.name}#{association.to_s.singularize.capitalize}".to_sym
+  def self.ensure_property_set_class(association, owner_class_name)
+    const_name = "#{owner_class_name}#{association.to_s.singularize.capitalize}".to_sym
     unless Object.const_defined?(const_name)
       property_class = Object.const_set(const_name, Class.new(ActiveRecord::Base))
       property_class.class_eval do
@@ -17,7 +17,7 @@ module PropertySets
         extend  PropertySets::PropertySetModel::ClassMethods
       end
 
-      property_class.owner_class = owner_class
+      property_class.owner_class = owner_class_name
       property_class.owner_assoc = association
     end
     Object.const_get(const_name)

--- a/lib/property_sets/active_record_extension.rb
+++ b/lib/property_sets/active_record_extension.rb
@@ -15,7 +15,10 @@ module PropertySets
         raise "Invalid association name, letters only" unless association.to_s =~ /[a-z]+/
         self.property_set_index << association
 
-        property_class = PropertySets.ensure_property_set_class(association, self)
+        property_class = PropertySets.ensure_property_set_class(
+          association,
+          options.delete(:owner_class_name) || self.name
+        )
         property_class.instance_eval(&block)
 
         hash_opts = {:class_name => property_class.name, :autosave => true, :dependent => :destroy}.merge(options)

--- a/lib/property_sets/property_set_model.rb
+++ b/lib/property_sets/property_set_model.rb
@@ -120,8 +120,8 @@ module PropertySets
         @properties[key] && !!@properties[key][:protected]
       end
 
-      def owner_class=(owner_class)
-        @owner_class_sym = owner_class.name.underscore.to_sym
+      def owner_class=(owner_class_name)
+        @owner_class_sym = owner_class_name.underscore.to_sym
         belongs_to              owner_class_sym
         validates_presence_of   owner_class_sym
         validates_uniqueness_of :name, :scope => owner_class_key_sym

--- a/test/test_property_sets.rb
+++ b/test/test_property_sets.rb
@@ -20,6 +20,14 @@ class TestPropertySets < ActiveSupport::TestCase
       end
     end
 
+    should "allow the owner class to be customized" do
+      (Flux = Class.new(ActiveRecord::Base)).property_set(:blot, {
+        :owner_class_name => 'Foobar'
+      }) { property :test }
+
+      assert defined?(FoobarBlot)
+    end
+
     should "pass-through any options from the second parameter" do
       Account.expects(:has_many).with { |association, h|
         association == :foo && h[:conditions] == "bar"


### PR DESCRIPTION
I find myself in a situation where I need to open up the `account_settings` property set to define a key/value pair, like so:

``` ruby
module Example
  class Account

    property_set :settings do
      property :foobar, :type => :boolean, :default => true
    end

  end
end
```

Because of the way `property_sets` works now, the `property_set` invocation attempts to infer the name of the AR class to be created from the call site, consequently defining the `Example::AccountSettings` constant. However, we need to access the table associated with simply `AccountSettings`.

This patch lets the `property_set` method accept an optional `owner_class_name` argument to be used in combination with the set name to refer to the AR class and table name.

See the added test for an example of how this would work.
### Why is this needed?

There are times when a AR class, such as `Account`, might not be defined. In those cases, we still need a way to work with property sets associated with those classes.

@kbuckler @morten @staugaard @grosser 
