### PR TITLE
introduce delegator as replacement for migrator

### DIFF
--- a/lib/property_sets/delegator.rb
+++ b/lib/property_sets/delegator.rb
@@ -1,0 +1,45 @@
+module PropertySets
+  module Delegator
+    # methods for moving what was once a literal column on
+    # to a property_set table.
+    #
+    # delegates read, write and query methods to the property record or the property default
+    #
+    # Examples
+    #
+    #   # Migrate :is_open to the :settings property set, and rename it :open,
+    #   # and migrate :same to property set :same
+    #   include PropertySets::Delegator
+    #   delegate_to_property_set :settings, :is_open => :open, :same => :same
+    #
+    def self.included(base)
+      base.extend(ClassMethods)
+    end
+
+    module ClassMethods
+      def delegate_to_property_set(setname, mappings)
+        raise "Second argument must be a Hash" unless mappings.is_a?(Hash)
+
+        mappings.each do |old_attr, new_attr|
+          define_method(old_attr) { send(setname).send(new_attr) }
+          alias_method "#{old_attr}_before_type_cast", old_attr
+          define_method("#{old_attr}?") { send(setname).send("#{new_attr}?") }
+          define_method("#{old_attr}=") { |value| send(setname).send("#{new_attr}=", value) }
+
+          define_method("#{old_attr}_changed?") do
+            assoc = send(setname)
+            setting = assoc.lookup_without_default(new_attr)
+
+            if !setting
+              false # Nothing has been set which means that the attribute hasn't changed
+            elsif setting.new_record?
+              assoc.default(new_attr) != setting.value
+            else
+              setting.value_changed?
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -30,6 +30,7 @@ require File.expand_path "../database", __FILE__
 
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 require 'property_sets'
+require 'property_sets/delegator'
 
 class ActiveSupport::TestCase
   include ActiveRecord::TestFixtures
@@ -56,6 +57,9 @@ class ActsLikeAnInteger
 end
 
 class Account < ActiveRecord::Base
+  include PropertySets::Delegator
+  delegate_to_property_set :settings, :old => :hep
+
   if ActiveRecord::VERSION::MAJOR < 4
     attr_accessible :name
     attr_accessible :texts_attributes

--- a/test/test_delegator.rb
+++ b/test/test_delegator.rb
@@ -1,0 +1,78 @@
+require File.expand_path(File.dirname(__FILE__) + '/helper')
+
+class TestDelegator < ActiveSupport::TestCase
+  context PropertySets::Delegator do
+    fixtures :accounts, :account_settings, :account_texts
+
+    setup do
+      @account = Account.create(:name => "Name")
+      @default = 'skep'
+    end
+
+    context "read" do
+      should "not add a property" do
+        @account.old
+        assert_equal 0, @account.settings.size
+      end
+
+      should "delegate read to default" do
+        assert_equal @default, @account.old
+      end
+
+      should "delegate read to property value" do
+        @account.settings.hep = 'new'
+        assert_equal 'new', @account.old
+      end
+    end
+
+    context "write" do
+      should "add a property" do
+        @account.old = 'new'
+        assert_equal 1, @account.settings.size
+      end
+
+      should "delegate write" do
+        @account.old = 'new'
+        assert_equal 'new', @account.settings.hep
+        assert_equal 'new', @account.old
+      end
+    end
+
+    context "changed?" do
+      should "not add a property" do
+        @account.old_changed?
+        assert_equal 0, @account.settings.size
+      end
+
+      should "not be changed" do
+        assert_equal false, @account.old_changed?
+      end
+
+      should "be changed with new value" do
+        @account.old = "new"
+        assert_equal true, @account.old_changed?
+      end
+
+      should "not be changed with default value" do
+        @account.old = @default
+        assert_equal false, @account.old_changed?
+      end
+    end
+
+    context "before_type_case" do
+      should "not add a property" do
+        @account.old_before_type_cast
+        assert_equal 0, @account.settings.size
+      end
+
+      should "return default" do
+        assert_equal @default, @account.old_before_type_cast
+      end
+
+      should "return setting" do
+        @account.old = "new"
+        assert_equal "new", @account.old_before_type_cast
+      end
+    end
+  end
+end


### PR DESCRIPTION
we keep the migrator code in case we need it someplace else and just add this handy new feature to property set

@edsinclair @eac  @morten 
