### PR TITLE
Compatibility with Rails 5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,11 @@ gemfile:
   - gemfiles/rails4.1.gemfile
   - gemfiles/rails4.2.gemfile
   - gemfiles/rails5.0.gemfile
+matrix:
+  exclude:
+    - rvm: 2.0.0
+      gemfile: gemfiles/rails5.0.gemfile
+    - rvm: 2.1.6
+      gemfile: gemfiles/rails5.0.gemfile
+    - rvm: rbx-2
+      gemfile: gemfiles/rails5.0.gemfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,20 +7,10 @@ rvm:
   - 2.0.0
   - 2.1.6
   - 2.2.2
-  - jruby
   - rbx-2
 script: "bundle exec rake test"
 gemfile:
-  - gemfiles/rails3.2.gemfile
   - gemfiles/rails4.0.gemfile
   - gemfiles/rails4.1.gemfile
   - gemfiles/rails4.2.gemfile
-matrix:
-  exclude:
-    - rvm: 2.2.2
-      gemfile: gemfiles/rails3.2.gemfile
-    - rvm: rbx-2
-      gemfile: gemfiles/rails3.2.gemfile
-  allow_failures:
-    - rvm: jruby
-      gemfile: gemfiles/rails4.2.gemfile
+  - gemfiles/rails5.0.gemfile

--- a/gemfiles/common.rb
+++ b/gemfiles/common.rb
@@ -1,3 +1,2 @@
 gem 'activerecord-jdbcmysql-adapter', '1.3.5', :platforms => :jruby
-gem 'mysql2', :platforms => :ruby
 gem 'iconv', :platforms => [:ruby_20, :ruby_21]

--- a/gemfiles/rails4.0.gemfile
+++ b/gemfiles/rails4.0.gemfile
@@ -3,5 +3,6 @@ source "https://rubygems.org"
 gemspec :path=>"../"
 
 gem "activerecord", "~> 4.0.6"
+gem "mysql2", '~> 0.3.0', :platforms => :ruby
 
 eval(File.read('gemfiles/common.rb'))

--- a/gemfiles/rails4.1.gemfile
+++ b/gemfiles/rails4.1.gemfile
@@ -3,5 +3,6 @@ source "https://rubygems.org"
 gemspec :path=>"../"
 
 gem "activerecord", "~> 4.1.0"
+gem "mysql2", '~> 0.3.0', :platforms => :ruby
 
 eval(File.read('gemfiles/common.rb'))

--- a/gemfiles/rails4.2.gemfile
+++ b/gemfiles/rails4.2.gemfile
@@ -4,5 +4,6 @@ gemspec :path=>"../"
 
 gem "activerecord", "~> 4.2.1"
 gem "actionview", "~> 4.2.1"
+gem "mysql2", :platforms => :ruby
 
 eval(File.read('gemfiles/common.rb'))

--- a/gemfiles/rails5.0.gemfile
+++ b/gemfiles/rails5.0.gemfile
@@ -4,5 +4,6 @@ gemspec :path=>"../"
 
 gem "activerecord", "5.0.0.beta1"
 gem "actionpack", "5.0.0.beta1"
+gem "mysql2", :platforms => :ruby
 
 eval(File.read('gemfiles/common.rb'))

--- a/gemfiles/rails5.0.gemfile
+++ b/gemfiles/rails5.0.gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gemspec :path=>"../"
 
-gem "activerecord", "~> 3.2.19"
-gem "minitest", "~> 4.7.5"
+gem "activerecord", "5.0.0.beta1"
+gem "actionpack", "5.0.0.beta1"
 
 eval(File.read('gemfiles/common.rb'))

--- a/lib/property_sets/active_record_extension.rb
+++ b/lib/property_sets/active_record_extension.rb
@@ -7,7 +7,7 @@ module PropertySets
 
       def property_set(association, options = {}, &block)
         unless include?(PropertySets::ActiveRecordExtension::InstanceMethods)
-          self.send(:include, PropertySets::ActiveRecordExtension::InstanceMethods)
+          self.send(:prepend, PropertySets::ActiveRecordExtension::InstanceMethods)
           cattr_accessor :property_set_index
           self.property_set_index = []
         end
@@ -157,13 +157,7 @@ module PropertySets
       end
 
       def association_class
-        @association_class ||= begin
-          if ActiveRecord::VERSION::STRING >= "3.1.0"
-            proxy_association.klass
-          else
-            @reflection.klass
-          end
-        end
+        @association_class ||= proxy_association.klass
       end
     end
 
@@ -173,14 +167,14 @@ module PropertySets
         base.alias_method_chain :update_attributes!, :property_sets
       end
 
-      def update_attributes_with_property_sets(attributes)
+      def update_attributes(attributes)
         update_property_set_attributes(attributes)
-        update_attributes_without_property_sets(attributes)
+        super(attributes)
       end
 
-      def update_attributes_with_property_sets!(attributes)
+      def update_attributes!(attributes)
         update_property_set_attributes(attributes)
-        update_attributes_without_property_sets!(attributes)
+        super(attributes)
       end
 
       def update_property_set_attributes(attributes)

--- a/lib/property_sets/active_record_extension.rb
+++ b/lib/property_sets/active_record_extension.rb
@@ -162,19 +162,14 @@ module PropertySets
     end
 
     module InstanceMethods
-      def self.included(base)
-        base.alias_method_chain :update_attributes, :property_sets
-        base.alias_method_chain :update_attributes!, :property_sets
-      end
-
       def update_attributes(attributes)
         update_property_set_attributes(attributes)
-        super(attributes)
+        super
       end
 
       def update_attributes!(attributes)
         update_property_set_attributes(attributes)
-        super(attributes)
+        super
       end
 
       def update_property_set_attributes(attributes)

--- a/property_sets.gemspec
+++ b/property_sets.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new "property_sets", PropertySets::VERSION do |s|
   s.homepage = 'http://github.com/zendesk/property_sets'
   s.license  = 'Apache License Version 2.0'
 
-  s.add_runtime_dependency("activerecord", ">= 3.2", "< 4.3")
+  s.add_runtime_dependency("activerecord", ">= 4.0", "< 5.1")
   s.add_runtime_dependency("json")
 
   s.add_development_dependency("bump")
@@ -17,7 +17,7 @@ Gem::Specification.new "property_sets", PropertySets::VERSION do |s|
   s.add_development_dependency('actionpack')
   s.add_development_dependency('minitest')
   s.add_development_dependency('minitest-rg')
-  s.add_development_dependency('wwtd', '>= 0.5.3')
+  s.add_development_dependency('wwtd')
 
   s.files = `git ls-files lib`.split("\n")
   s.license = "MIT"

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -17,22 +17,22 @@ require 'property_sets'
 require 'property_sets/delegator'
 
 class Minitest::Spec
-  include ActiveSupport::Testing::SetupAndTeardown
   include ActiveRecord::TestFixtures
 
-  case
-  when ActiveRecord::VERSION::MAJOR == 3
+  if ActiveRecord::VERSION::STRING < '4.1.0'
     alias :method_name :__name__ if defined? :__name__
-  when ActiveRecord::VERSION::MAJOR == 4 && ActiveRecord::VERSION::MINOR < 1
-    alias :method_name :__name__ if defined? :__name__
-  when ActiveRecord::VERSION::MAJOR == 4 && ActiveRecord::VERSION::MINOR >= 1
+  else
     alias :method_name :name if defined? :name
   end
 
   self.fixture_path = File.dirname(__FILE__) + "/fixtures/"
   $LOAD_PATH.unshift(self.fixture_path)
 
-  self.use_transactional_fixtures = true
+  if self.respond_to?(:use_transactional_tests=)
+    self.use_transactional_tests = true
+  else
+    self.use_transactional_fixtures = true
+  end
   self.use_instantiated_fixtures  = false
 end
 

--- a/test/test_property_sets.rb
+++ b/test/test_property_sets.rb
@@ -99,8 +99,8 @@ describe PropertySets do
     valids   = %w(hello hel_lo hell0)
     invalids = %w(_hello)
 
-    if ActiveRecord::VERSION::MAJOR == 4 && ActiveRecord::VERSION::MINOR >= 2
-      valids += [:hello] # gets casted back to String with Rails 4.2
+    if ActiveRecord::VERSION::STRING >= '4.2.0'
+      valids += [:hello] # gets casted back to String with Rails 4.2/5.0
     else
       invalids += [:hello, 42, 3.14156]
     end

--- a/test/test_view_extensions.rb
+++ b/test/test_view_extensions.rb
@@ -9,15 +9,13 @@ describe "property set view extensions" do
     }
   end
 
-  let(:builder_args) { ActiveRecord::VERSION::MAJOR == 3 ? ['proc'] : [] }
-
   before do
     @property_set = :settings
     @property     = :active
     @object_name  = 'object_name'
     @object       = stub
     @template     = stub
-    @builder      = ActionView::Helpers::FormBuilder.new(@object_name, @object, @template, {}, *builder_args)
+    @builder      = ActionView::Helpers::FormBuilder.new(@object_name, @object, @template, {})
     @proxy        = @builder.property_set(@property_set)
   end
 
@@ -27,7 +25,7 @@ describe "property set view extensions" do
   end
 
   it "fetch the target object when not available" do
-    @builder = ActionView::Helpers::FormBuilder.new(@object_name, nil, @template, {}, *builder_args)
+    @builder = ActionView::Helpers::FormBuilder.new(@object_name, nil, @template, {})
     @proxy   = @builder.property_set(@property_set)
 
     @object.stubs(@property_set).returns(stub(@property => 'value'))


### PR DESCRIPTION
/cc @zendesk/zendesk-rails-upgraders 

![mind blown](http://img.pandawhale.com/post-28553-Steve-Jobs-mind-blown-gif-HD-T-pVbd.gif)

 * Removing alias_method_chain in favour of prepend
 * Removing attr_accessible (protected_attributes won't be compatible with Rails 5.0)
 * Fixing some ActiveRecord version checks