### PR TITLE
support all of the sql text/blob column types and their lengths

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ rvm:
   - 2.0.0
   - 2.1.6
   - 2.2.2
-  - rbx-2
 script: "bundle exec rake spec"
 gemfile:
   - gemfiles/rails3.2.gemfile
@@ -18,8 +17,8 @@ gemfile:
 matrix:
   exclude:
     - rvm: 2.0.0
+      gemfile: gemfiles/rails4.2.gemfile # causes a weird nokogiri install problem
+    - rvm: 2.0.0
       gemfile: gemfiles/rails5.0.gemfile
     - rvm: 2.1.6
-      gemfile: gemfiles/rails5.0.gemfile
-    - rvm: rbx-2
       gemfile: gemfiles/rails5.0.gemfile

--- a/README.md
+++ b/README.md
@@ -119,9 +119,22 @@ Also remember to create the storage table(s), if for example you are going to be
 
 ```ruby
 create_table :account_settings do |t|
-  t.integer  :account_id, :null => false
-  t.string   :name, :null => false
-  t.string   :value
+  t.integer :account_id, :null => false
+  t.string  :name, :null => false
+  t.string  :value
+  t.timestamps
+end
+
+add_index :account_settings, [ :account_id, :name ], :unique => true
+```
+
+If you would like to serialize larger objects into your property sets, you can use a `TEXT` column type for value like this:
+
+```
+create_table :account_settings do |t|
+  t.integer :account_id, :null => false
+  t.string  :name, :null => false
+  t.text    :value
   t.timestamps
 end
 

--- a/lib/property_sets/property_set_model.rb
+++ b/lib/property_sets/property_set_model.rb
@@ -2,20 +2,19 @@ require 'active_support'
 
 module PropertySets
   module PropertySetModel
-    module InstanceMethods
-      # https://dev.mysql.com/doc/refman/5.6/en/storage-requirements.html
-      COLUMN_TYPE_LIMITS = {
-        'tinyblob'   => 255,        # 2^8 - 1
-        'tinytext'   => 255,
-        'blob'       => 65535,      # 2^16 - 1
-        'text'       => 65535,
-        'mediumblob' => 16777215,   # 2^24 - 1
-        'mediumtext' => 16777215,
-        'longblob'   => 4294967295, # 2^32 - 1
-        'longtext'   => 4294967295,
-      }.freeze
-      private_constant :COLUMN_TYPE_LIMITS
+    # https://dev.mysql.com/doc/refman/5.6/en/storage-requirements.html
+    COLUMN_TYPE_LIMITS = {
+      'tinyblob'   => 255,        # 2^8 - 1
+      'tinytext'   => 255,
+      'blob'       => 65535,      # 2^16 - 1
+      'text'       => 65535,
+      'mediumblob' => 16777215,   # 2^24 - 1
+      'mediumtext' => 16777215,
+      'longblob'   => 4294967295, # 2^32 - 1
+      'longtext'   => 4294967295,
+    }.freeze
 
+    module InstanceMethods
       def false?
         [ "false", "0", "", "off", "n" ].member?(value.to_s.downcase)
       end
@@ -78,7 +77,7 @@ module PropertySets
       end
 
       def validate_length_of_serialized_data
-        if value_serialized && self.read_attribute(:value).to_s.size > value_column_limit
+        if value_serialized && read_attribute(:value).to_s.size > value_column_limit
           errors.add(:value, :invalid)
         end
       end
@@ -94,10 +93,10 @@ module PropertySets
       end
 
       def value_column_limit
-        column = self.class.columns_hash['value']
+        column = self.class.columns_hash.fetch('value')
 
         # use sql_type because type returns :text for all text types regardless of length
-        column.limit || COLUMN_TYPE_LIMITS[column.sql_type]
+        column.limit || COLUMN_TYPE_LIMITS.fetch(column.sql_type)
       end
     end
 

--- a/property_sets.gemspec
+++ b/property_sets.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new "property_sets", PropertySets::VERSION do |s|
   s.add_development_dependency('actionpack')
   s.add_development_dependency('rspec')
   s.add_development_dependency('wwtd', '>= 0.5.3')
+  s.add_development_dependency('byebug')
 
   s.files = `git ls-files lib`.split("\n")
   s.license = "MIT"

--- a/spec/property_sets_spec.rb
+++ b/spec/property_sets_spec.rb
@@ -416,6 +416,12 @@ describe PropertySets do
         expect(account.save).to be false
       end
 
+      it "not overflow on other text types" do
+        account.tiny_texts.serialized = (1..2**10).to_a # column size is 2^8 - 1
+        expect(account.tiny_texts.lookup(:serialized)).to_not be_valid
+        expect(account.save).to be false
+      end
+
       it "allow for destructive operators" do
         value = {:a => 1, :b => 2}
         account.typed_data.serialized_prop = value

--- a/spec/support/account.rb
+++ b/spec/support/account.rb
@@ -42,4 +42,8 @@ class Account < ActiveRecord::Base
     property :default_prop, :type => :integer, :default => ActsLikeAnInteger.new
     property :serialized_prop_with_default, :type => :serialized, :default => "[]"
   end
+
+  property_set :tiny_texts do
+    property :serialized, :type => :serialized
+  end
 end

--- a/spec/support/database.rb
+++ b/spec/support/database.rb
@@ -77,6 +77,16 @@ ActiveRecord::Schema.define(:version => 1) do
 
   add_index :account_benchmark_settings, [ :account_id, :name ], :unique => true
 
+  create_table "account_tiny_texts", :force => true do |t|
+    t.integer  "account_id"
+    t.string   "name"
+    t.text     "value",      :limit => (2**8 - 1)
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index :account_tiny_texts, [ :account_id, :name ], :unique => true
+
   create_table "accounts", :force => true do |t|
     t.string   "name"
     t.datetime "created_at"


### PR DESCRIPTION
Sometimes you want to serialize a property and a standard `varchar(255)` column isn't long enough. This adds in support for all of the "text" style columns that SQL supports. 

/cc @grosser @zendesk/sustaining