### PR TITLE
property_set_index: prevent duplicates

### DIFF
--- a/lib/property_sets/active_record_extension.rb
+++ b/lib/property_sets/active_record_extension.rb
@@ -1,5 +1,6 @@
 require 'active_record'
 require 'property_sets/casting'
+require 'set'
 
 module PropertySets
   module ActiveRecordExtension
@@ -9,11 +10,11 @@ module PropertySets
         unless include?(PropertySets::ActiveRecordExtension::InstanceMethods)
           self.send(:prepend, PropertySets::ActiveRecordExtension::InstanceMethods)
           cattr_accessor :property_set_index
-          self.property_set_index = []
+          self.property_set_index = Set.new
         end
 
         raise "Invalid association name, letters only" unless association.to_s =~ /[a-z]+/
-        self.property_set_index << association unless self.property_set_index.include?(association)
+        self.property_set_index << association
 
         property_class = PropertySets.ensure_property_set_class(
           association,

--- a/lib/property_sets/active_record_extension.rb
+++ b/lib/property_sets/active_record_extension.rb
@@ -13,7 +13,7 @@ module PropertySets
         end
 
         raise "Invalid association name, letters only" unless association.to_s =~ /[a-z]+/
-        self.property_set_index << association
+        self.property_set_index << association unless self.property_set_index.include?(association)
 
         property_class = PropertySets.ensure_property_set_class(
           association,

--- a/spec/property_sets_spec.rb
+++ b/spec/property_sets_spec.rb
@@ -13,6 +13,7 @@ describe PropertySets do
     %i(settings texts validations typed_data).each do |name|
       expect(Account.property_set_index).to include(name)
     end
+    expect(Account.property_set_index.size).to eq(Account.property_set_index.uniq.size)
   end
 
   it "allow the owner class to be customized" do

--- a/spec/property_sets_spec.rb
+++ b/spec/property_sets_spec.rb
@@ -13,7 +13,6 @@ describe PropertySets do
     %i(settings texts validations typed_data).each do |name|
       expect(Account.property_set_index).to include(name)
     end
-    expect(Account.property_set_index.size).to eq(Account.property_set_index.uniq.size)
   end
 
   it "allow the owner class to be customized" do


### PR DESCRIPTION
### Description

Calling `property_set` multiple times with the same association would add duplicates (of the same object) to `property_set_index`:
```
(byebug) Account.property_set_index
[:settings, :settings, :texts, :validations, :typed_data, :tiny_texts]
```

Wouldn't cause bugs, but `update_property_set_attributes` would loop through all property_set_index elements including duplicates.

/cc @grosser @pschambacher @craig-day @bquorning 