### PR TITLE
Prevent CollectionProxy#scoping calls

### DIFF
--- a/lib/property_sets/active_record_extension.rb
+++ b/lib/property_sets/active_record_extension.rb
@@ -85,7 +85,7 @@ module PropertySets
         property_pairs.keys.each do |name|
           record = lookup(name)
           if with_protection && record.protected?
-            logger.warn("Someone tried to update the protected #{name} property to #{property_pairs[name]}")
+            association_class.logger.warn("Someone tried to update the protected #{name} property to #{property_pairs[name]}")
           else
             send("#{name}=", property_pairs[name])
           end
@@ -113,11 +113,16 @@ module PropertySets
       end
 
       def build_default(arg)
-        build(:name => arg.to_s, :value => raw_default(arg))
+        build(:name => arg.to_s, :value => association_class.raw_default(arg))
       end
 
       def lookup_without_default(arg)
         detect { |property| property.name.to_sym == arg.to_sym }
+      end
+
+      # Tests call default on the collection proxy
+      def default(*args)
+        association_class.default(*args)
       end
 
       def lookup_value(type, key)
@@ -127,7 +132,7 @@ module PropertySets
           instance.value_serialized = serialized
           PropertySets::Casting.read(type, instance.value)
         else
-          value = default(key)
+          value = association_class.default(key)
           if serialized
             PropertySets::Casting.deserialize(value)
           else
@@ -144,7 +149,7 @@ module PropertySets
 
         owner = proxy_association.owner
 
-        instance.send("#{owner_class_sym}=", owner) if owner.new_record?
+        instance.send("#{association_class.owner_class_sym}=", owner) if owner.new_record?
         instance
       end
 
@@ -152,7 +157,7 @@ module PropertySets
       # It does not have the side effect of adding a new setting object.
       def lookup_or_default(arg)
         instance = lookup_without_default(arg)
-        instance ||= association_class.new(:value => raw_default(arg))
+        instance ||= association_class.new(:value => association_class.raw_default(arg))
         instance.value_serialized = property_serialized?(arg)
         instance
       end

--- a/lib/property_sets/active_record_extension.rb
+++ b/lib/property_sets/active_record_extension.rb
@@ -120,11 +120,6 @@ module PropertySets
         detect { |property| property.name.to_sym == arg.to_sym }
       end
 
-      # Tests call default on the collection proxy
-      def default(*args)
-        association_class.default(*args)
-      end
-
       def lookup_value(type, key)
         serialized = property_serialized?(key)
 

--- a/lib/property_sets/delegator.rb
+++ b/lib/property_sets/delegator.rb
@@ -27,14 +27,14 @@ module PropertySets
           define_method("#{old_attr}=") { |value| send(setname).send("#{new_attr}=", value) }
 
           define_method("#{old_attr}_changed?") do
-            assoc = send(setname)
-            return false unless assoc.loaded?
-            setting = assoc.lookup_without_default(new_attr)
+            collection_proxy = send(setname)
+            return false unless collection_proxy.loaded?
+            setting = collection_proxy.lookup_without_default(new_attr)
 
             if !setting
               false # Nothing has been set which means that the attribute hasn't changed
             elsif setting.new_record?
-              assoc.default(new_attr) != setting.value
+              collection_proxy.association_class.default(new_attr) != setting.value
             else
               setting.value_changed?
             end

--- a/spec/property_sets_spec.rb
+++ b/spec/property_sets_spec.rb
@@ -72,8 +72,8 @@ describe PropertySets do
   end
 
   it "be flexible when fetching property data" do
-    expect(account.settings.default(:hep)) .to eq('skep')
-    expect(account.settings.default('hep')).to eq('skep')
+    expect(account.settings.association_class.default(:hep)) .to eq('skep')
+    expect(account.settings.association_class.default('hep')).to eq('skep')
   end
 
   describe 'querying for a setting that does not exist' do
@@ -348,7 +348,7 @@ describe PropertySets do
   describe "typed columns" do
 
     it "typecast the default value" do
-      expect(account.typed_data.default(:default_prop)).to eq(123)
+      expect(account.typed_data.association_class.default(:default_prop)).to eq(123)
     end
 
     describe "string data" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,4 +30,14 @@ module QueryAssertions
   end
 end
 
+module ActiveRecord
+  module Associations
+    class CollectionProxy
+      def scoping
+        raise 'CollectionProxy delegates unknown methods to target (association_class) via method_missing, wrapping the call with `scoping`. Instead, call the method directly on the association_class!'
+      end
+    end
+  end
+end
+
 RSpec.configure { |c| c.include QueryAssertions }


### PR DESCRIPTION
### Description

While doing some performance work, noticed those calls:

![screen shot 2017-11-10 at 3 49 08 pm](https://user-images.githubusercontent.com/697824/32683261-e616db44-c62e-11e7-90de-20df823f1240.png)

@grosser said those can be prevented and we should add a fix here.

CollectionProxy delegates unknown methods to @target via method_missing, wrapping the call with `scoping`. We can prevent it by calling the methods directly in the target.

@grosser @pschambacher @craig-day @bquorning  