### PR TITLE
update uniqueness validator per deprecations in dependent gems

### DIFF
--- a/lib/property_sets/property_set_model.rb
+++ b/lib/property_sets/property_set_model.rb
@@ -137,7 +137,7 @@ module PropertySets
         @owner_class_sym = owner_class_name.underscore.to_sym
         belongs_to              owner_class_sym
         validates_presence_of   owner_class_sym
-        validates_uniqueness_of :name, :scope => owner_class_key_sym
+        validates_uniqueness_of :name, :scope => owner_class_key_sym, :case_sensitive => false
         attr_accessible         owner_class_key_sym, owner_class_sym if defined?(ProtectedAttributes)
       end
 


### PR DESCRIPTION
### Description
Uniqueness validation fails without case_sensitive in gems that depend on arturo and it will be deprecated in Rails 6.1

### Reference
JIRA: https://zendesk.atlassian.net/browse/WALR-2076
Issue: https://github.com/rails/rails/commit/9def05385f1cfa41924bb93daa187615e88c95b9

### Risks
**Low**