### PR TITLE
[R5U-1126] Track changes when values are set through forwarded methods

### DIFF
--- a/lib/property_sets/active_record_extension.rb
+++ b/lib/property_sets/active_record_extension.rb
@@ -163,15 +163,17 @@ module PropertySets
     end
 
     module InstanceMethods
-      def update_attributes(attributes)
+      def update(attributes)
         update_property_set_attributes(attributes)
         super
       end
+      alias update_attributes update
 
-      def update_attributes!(attributes)
+      def update!(attributes)
         update_property_set_attributes(attributes)
         super
       end
+      alias update_attributes! update!
 
       def update_property_set_attributes(attributes)
         if attributes && self.class.property_set_index.any?

--- a/lib/property_sets/delegator.rb
+++ b/lib/property_sets/delegator.rb
@@ -21,16 +21,17 @@ module PropertySets
         raise "Second argument must be a Hash" unless mappings.is_a?(Hash)
 
         mappings.each do |old_attr, new_attr|
-          if ActiveRecord.version >= Gem::Version.new('5.0')
+          if ActiveRecord.version < Gem::Version.new("5.0")
+            attribute old_attr, ActiveRecord::Type::Value.new
+          else
             attribute old_attr, ActiveModel::Type::Value.new
           end
           define_method(old_attr) { send(setname).send(new_attr) }
           alias_method "#{old_attr}_before_type_cast", old_attr
           define_method("#{old_attr}?") { send(setname).send("#{new_attr}?") }
-          define_method("#{old_attr}_will_change!"){ attribute_will_change!(old_attr) }
           define_method("#{old_attr}=") do |value|
-            send("#{old_attr}_will_change!")
             send(setname).send("#{new_attr}=", value)
+            super(value)
           end
 
           define_method("#{old_attr}_changed?") do

--- a/lib/property_sets/delegator.rb
+++ b/lib/property_sets/delegator.rb
@@ -21,6 +21,9 @@ module PropertySets
         raise "Second argument must be a Hash" unless mappings.is_a?(Hash)
 
         mappings.each do |old_attr, new_attr|
+          if ActiveRecord.version >= Gem::Version.new('5.0')
+            attribute old_attr, ActiveModel::Type::Value.new
+          end
           define_method(old_attr) { send(setname).send(new_attr) }
           alias_method "#{old_attr}_before_type_cast", old_attr
           define_method("#{old_attr}?") { send(setname).send("#{new_attr}?") }

--- a/lib/property_sets/delegator.rb
+++ b/lib/property_sets/delegator.rb
@@ -24,7 +24,11 @@ module PropertySets
           define_method(old_attr) { send(setname).send(new_attr) }
           alias_method "#{old_attr}_before_type_cast", old_attr
           define_method("#{old_attr}?") { send(setname).send("#{new_attr}?") }
-          define_method("#{old_attr}=") { |value| send(setname).send("#{new_attr}=", value) }
+          define_method("#{old_attr}_will_change!"){ attribute_will_change!(old_attr) }
+          define_method("#{old_attr}=") do |value|
+            send("#{old_attr}_will_change!")
+            send(setname).send("#{new_attr}=", value)
+          end
 
           define_method("#{old_attr}_changed?") do
             collection_proxy = send(setname)

--- a/spec/property_sets_spec.rb
+++ b/spec/property_sets_spec.rb
@@ -339,6 +339,21 @@ describe PropertySets do
     end
   end
 
+  describe "update_attribute" do
+    it "updates changed attributes" do
+      account.update_attribute(:old, "it works!")
+      expect(account.old).to eq("it works!")
+      expect(Account.find(account.id).old).to eq("it works!")
+    end
+
+    it "updates changed attributes through association" do
+      account.settings.hep = "it works!"
+      account.save
+      expect(account.settings.hep).to eq("it works!")
+      expect(Account.find(account.id).old).to eq("it works!")
+    end
+  end
+
   describe "typed columns" do
 
     it "typecast the default value" do

--- a/spec/property_sets_spec.rb
+++ b/spec/property_sets_spec.rb
@@ -339,17 +339,10 @@ describe PropertySets do
     end
   end
 
-  describe "update_attribute" do
+  describe "update_attribute for forwarded method" do
     it "updates changed attributes" do
       account.update_attribute(:old, "it works!")
-      expect(account.old).to eq("it works!")
-      expect(Account.find(account.id).old).to eq("it works!")
-    end
-
-    it "updates changed attributes through association" do
-      account.settings.hep = "it works!"
-      account.save
-      expect(account.settings.hep).to eq("it works!")
+      expect(account.previous_changes["old"].last).to eq("it works!")
       expect(Account.find(account.id).old).to eq("it works!")
     end
   end


### PR DESCRIPTION
Fixes #69 
Addresses R5U-1126

When updating attributes, ActiveRecord needs to be notified of the incoming change.

This also removes references to the deprecated `update_attributes` methods and sets forwarded attributes on the main model using `delegate_to_property_set` as an `attribute`