### PR TITLE
[R5U-1459] automatically inherit delegated_property_set_attributes with delegate_to_property_set

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,19 @@ account.settings.set(:version => "v1.2", :activated => true)
 account.settings.get([:version, :activated])
 ```
 
+You can also forward read, write and query methods to the properties with `PropertySets::Delegator`.
+
+```
+class Account < ActiveRecord::Base
+  include PropertySets::Delegator
+  delegate_to_property_set :settings, :is_open => :open, :same => :same
+end
+
+account.open #=> account.settings.is_open
+```
+
+These classes and their subclasses will inherit specified properties.
+
 ### Validations
 
 Property sets supports standard AR validations, although in a somewhat manual fashion.

--- a/lib/property_sets/delegator.rb
+++ b/lib/property_sets/delegator.rb
@@ -20,7 +20,10 @@ module PropertySets
       def delegate_to_property_set(setname, mappings)
         raise "Second argument must be a Hash" unless mappings.is_a?(Hash)
 
-        @delegated_property_set_attributes ||= []
+        unless respond_to?(:delegated_property_set_attributes)
+          class_attribute :delegated_property_set_attributes
+        end
+        self.delegated_property_set_attributes ||= []
 
         mappings.each do |old_attr, new_attr|
           self.delegated_property_set_attributes << old_attr.to_s
@@ -60,12 +63,8 @@ module PropertySets
         # These are not database columns and should not be included in queries but
         # using the attributes API is the only way to track changes in the main model
         if respond_to?(:user_provided_columns)
-          self.user_provided_columns.reject!{|k,_| @delegated_property_set_attributes.include?(k.to_s) }
+          self.user_provided_columns.reject!{|k,_| delegated_property_set_attributes.include?(k.to_s) }
         end
-      end
-
-      def delegated_property_set_attributes
-        @delegated_property_set_attributes
       end
     end
   end

--- a/spec/support/account.rb
+++ b/spec/support/account.rb
@@ -50,8 +50,5 @@ end
 
 module Other
   class Account < ::Account
-    def self.delegated_property_set_attributes
-      ::Account.delegated_property_set_attributes
-    end
   end
 end


### PR DESCRIPTION
Updates the use of `delegate_to_property_set` to use a `class_attribute` for tracking forwarded methods that are not database columns.