### PR TITLE
Get value instead of collection

### DIFF
--- a/lib/property_sets/active_record_extension.rb
+++ b/lib/property_sets/active_record_extension.rb
@@ -123,7 +123,7 @@ module PropertySets
       end
 
       def lookup_without_default(arg)
-        detect { |property| property.name.to_sym == arg.to_sym }
+        find_by(name: arg)
       end
 
       def lookup_value(type, key)


### PR DESCRIPTION
Accessing a single property causes a read of every property. Change that.