### PR TITLE
Make property_set idempotent(ish). Only ever call has_many once.

### DIFF
--- a/lib/property_sets/active_record_extension.rb
+++ b/lib/property_sets/active_record_extension.rb
@@ -31,6 +31,7 @@ module PropertySets
           :class_name => property_class.name,
           :autosave => true,
           :dependent => :destroy,
+          :inverse_of => self.name.underscore.to_sym,
         }.merge(options)
 
         silence_warnings do

--- a/lib/property_sets/active_record_extension.rb
+++ b/lib/property_sets/active_record_extension.rb
@@ -24,6 +24,9 @@ module PropertySets
         # eg property :is_awesome
         property_class.instance_eval(&block) if block
 
+        tb_name = options.delete :table_name
+        property_class.table_name = tb_name if tb_name
+
         hash_opts = {
           :class_name => property_class.name,
           :autosave => true,

--- a/lib/property_sets/active_record_extension.rb
+++ b/lib/property_sets/active_record_extension.rb
@@ -6,6 +6,8 @@ module PropertySets
   module ActiveRecordExtension
     module ClassMethods
 
+      RAILS6 = ActiveRecord::VERSION::MAJOR >= 6
+
       def property_set(association, options = {}, &block)
         unless include?(PropertySets::ActiveRecordExtension::InstanceMethods)
           self.send(:prepend, PropertySets::ActiveRecordExtension::InstanceMethods)
@@ -14,8 +16,11 @@ module PropertySets
         end
 
         raise "Invalid association name, letters only" unless association.to_s =~ /[a-z]+/
+        exists = property_set_index.include?(association)
+
         self.property_set_index << association
 
+        # eg AccountSetting - this IS idempotent
         property_class = PropertySets.ensure_property_set_class(
           association,
           options.delete(:owner_class_name) || self.name
@@ -34,41 +39,60 @@ module PropertySets
           :inverse_of => self.name.underscore.to_sym,
         }.merge(options)
 
-        silence_warnings do
+        # TODO: should check options are compatible? warn? raise?
+        reflection = self.reflections[association.to_s] # => ActiveRecord::Reflection::HasManyReflection
+        reflection.options.merge! options if reflection && !options.empty?
+
+        unless exists then # makes has_many idempotent...
           has_many association, hash_opts do
-            include PropertySets::ActiveRecordExtension::AssociationExtensions
+            # keep this damn block! -- creates association_module below
+          end
+        end
 
-            property_class.keys.each do |key|
-              raise "Invalid property key #{key}" if self.respond_to?(key)
+        # eg 5: AccountSettingsAssociationExtension
+        # eg 6: Account::SettingsAssociationExtension
 
-              # Reports the coerced truth value of the property
-              define_method "#{key}?" do
-                type  = property_class.type(key)
-                value = lookup_value(type, key)
-                ![ "false", "0", "", "off", "n" ].member?(value.to_s.downcase)
-              end
+        # stolen/adapted from AR's collection_association.rb #define_extensions
 
-              # Returns the value of the property
-              define_method "#{key}" do
-                type = property_class.type(key)
-                lookup_value(type, key)
-              end
+        module_name = "#{association.to_s.camelize}AssociationExtension"
+        module_name = name.demodulize + module_name unless RAILS6
 
-              # Assigns a new value to the property
-              define_method "#{key}=" do |value|
-                instance = lookup(key)
-                instance.value = PropertySets::Casting.write(property_class.type(key), value)
-                instance.value
-              end
+        target = RAILS6 ? self : self.parent
+        association_module = target.const_get module_name
 
-              define_method "#{key}_record" do
-                lookup(key)
-              end
+        association_module.module_eval do
+          include PropertySets::ActiveRecordExtension::AssociationExtensions
+
+          property_class.keys.each do |key|
+            raise "Invalid property key #{key}" if self.respond_to?(key)
+
+            # Reports the coerced truth value of the property
+            define_method "#{key}?" do
+              type  = property_class.type(key)
+              value = lookup_value(type, key)
+              ![ "false", "0", "", "off", "n" ].member?(value.to_s.downcase)
             end
 
-            define_method :property_serialized? do |key|
-              property_class.type(key) == :serialized
+            # Returns the value of the property
+            define_method "#{key}" do
+              type = property_class.type(key)
+              lookup_value(type, key)
             end
+
+            # Assigns a new value to the property
+            define_method "#{key}=" do |value|
+              instance = lookup(key)
+              instance.value = PropertySets::Casting.write(property_class.type(key), value)
+              instance.value
+            end
+
+            define_method "#{key}_record" do
+              lookup(key)
+            end
+          end
+
+          define_method :property_serialized? do |key|
+            property_class.type(key) == :serialized
           end
         end
       end

--- a/spec/property_sets_spec.rb
+++ b/spec/property_sets_spec.rb
@@ -35,11 +35,14 @@ describe PropertySets do
   end
 
   it "pass-through any options from the second parameter" do
-    expect(Account).to receive(:has_many) { |association, h|
-      expect(association).to eq(:foo)
-      expect(h[:conditions]).to eq("bar")
-    }
-    Account.property_set(:foo, :conditions => "bar") {}
+    class AnotherThing < ActiveRecord::Base
+      self.table_name = "things" # cheat and reuse things table
+    end
+
+    AnotherThing.property_set(:settings, :extend => Account::Woot,
+                              :table_name => "thing_settings")
+
+    expect(AnotherThing.new.settings.extensions).to include(::Account::Woot)
   end
 
   it "support protecting attributes" do

--- a/spec/property_sets_spec.rb
+++ b/spec/property_sets_spec.rb
@@ -8,6 +8,7 @@ $-w = old
 
 describe PropertySets do
   let(:account) { Account.create(:name => "Name") }
+  let(:relation) { Account.reflections["settings"] }
 
   it "construct the container class" do
     expect(defined?(AccountSetting)).to be_truthy
@@ -19,6 +20,10 @@ describe PropertySets do
     %i(settings texts validations typed_data).each do |name|
       expect(Account.property_set_index).to include(name)
     end
+  end
+
+  it "sets inverse_of" do
+    expect(relation.inverse_of.klass).to eq Account
   end
 
   it "allow the owner class to be customized" do

--- a/spec/property_sets_spec.rb
+++ b/spec/property_sets_spec.rb
@@ -26,6 +26,11 @@ describe PropertySets do
     expect(relation.inverse_of.klass).to eq Account
   end
 
+  it "reopening property_set is idempotent, first one wins on options etc" do
+    expect(Array(relation.options[:extend])).to include Account::Woot
+    expect(account.settings.extensions).to include Account::Woot
+  end
+
   it "allow the owner class to be customized" do
     (Flux = Class.new(ActiveRecord::Base)).property_set(:blot, {
       :owner_class_name => 'Foobar'

--- a/spec/support/account.rb
+++ b/spec/support/account.rb
@@ -4,7 +4,11 @@ class Account < ActiveRecord::Base
   include PropertySets::Delegator
   delegate_to_property_set :settings, :old => :hep
 
-  property_set :settings do
+  # nonsense module to use in options below, only used as a marker
+  module Woot # doesn't actually seem to be used in AR4 ?
+  end
+
+  property_set :settings, extend: Woot do
     property :foo
     property :bar
     property :baz
@@ -15,7 +19,7 @@ class Account < ActiveRecord::Base
     property :bool_nil, :type => :boolean, :default => nil
   end
 
-  property_set :settings do
+  property_set :settings do # reopening should maintain `extend` above
     property :bool_nil2, :type => :boolean
   end
 


### PR DESCRIPTION
has_many isn't idempotent, and we lose information when we "re-open" a
property_set on the same model w/ the same association name.

This moves all the method creation outside of the has_many and puts it in
the right place via some reflection. This means we get to keep evaluating
the property_set blocks on the same thing, without destroying information
by calling has_many multiple times.

Also:

* Always set `inverse_of`.
* Pass table_name option to the relation class, not association extension.

ETA: A good portion of this diff is just a move / reindent... so view the diff with https://github.com/zendesk/property_sets/pull/84/files?diff=unified&w=1
