### PR TITLE
Drop ruby 2.4 and 2.5, add 3.0. Fix errors in 3.0.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,11 +31,6 @@ jobs:
             gemfile: rails5.1
           - ruby-version: 3.0
             gemfile: rails5.2
-          # These fail due to a legit bug:
-          - ruby-version: 3.0
-            gemfile: rails6.0
-          - ruby-version: 3.0
-            gemfile: rails6.1
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,9 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
-          - 2.4
-          - 2.5
           - 2.6
           - 2.7
+          - 3.0
         gemfile:
           - rails4.2
           - rails5.0
@@ -22,12 +21,21 @@ jobs:
           - rails6.0
           - rails6.1
         exclude:
-          - ruby-version: 2.4
-            gemfile: rails6.0
-          - ruby-version: 2.4
-            gemfile: rails6.1
           - ruby-version: 2.7
             gemfile: rails4.2
+          - ruby-version: 3.0
+            gemfile: rails4.2
+          - ruby-version: 3.0
+            gemfile: rails5.0
+          - ruby-version: 3.0
+            gemfile: rails5.1
+          - ruby-version: 3.0
+            gemfile: rails5.2
+          # These fail due to a legit bug:
+          - ruby-version: 3.0
+            gemfile: rails6.0
+          - ruby-version: 3.0
+            gemfile: rails6.1
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile
     steps:

--- a/lib/property_sets/active_record_extension.rb
+++ b/lib/property_sets/active_record_extension.rb
@@ -44,7 +44,7 @@ module PropertySets
         reflection.options.merge! options if reflection && !options.empty?
 
         unless exists then # makes has_many idempotent...
-          has_many association, hash_opts do
+          has_many association, **hash_opts do
             # keep this damn block! -- creates association_module below
           end
         end


### PR DESCRIPTION
This exposes (and allows) failures described in #85.