### PR TITLE
Small change for delegating arguments (and remove ruby 2.6 / rails4.2 from testing)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,13 +10,11 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
-          - '2.6'
           - '2.7'
           - '3.0'
           - '3.1'
           - '3.2'
         gemfile:
-          - rails4.2
           - rails5.0
           - rails5.1
           - rails5.2
@@ -24,18 +22,13 @@ jobs:
           - rails6.1
           - rails7.0
         exclude:
-          - {ruby-version: '2.6', gemfile: rails7.0}
-          - {ruby-version: '2.7', gemfile: rails4.2}
-          - {ruby-version: '3.0', gemfile: rails4.2}
           - {ruby-version: '3.0', gemfile: rails5.0}
           - {ruby-version: '3.0', gemfile: rails5.1}
           - {ruby-version: '3.0', gemfile: rails5.2}
-          - {ruby-version: '3.1', gemfile: rails4.2}
           - {ruby-version: '3.1', gemfile: rails5.0}
           - {ruby-version: '3.1', gemfile: rails5.1}
           - {ruby-version: '3.1', gemfile: rails5.2}
           - {ruby-version: '3.1', gemfile: rails6.0}
-          - {ruby-version: '3.2', gemfile: rails4.2}
           - {ruby-version: '3.2', gemfile: rails5.0}
           - {ruby-version: '3.2', gemfile: rails5.1}
           - {ruby-version: '3.2', gemfile: rails5.2}

--- a/.github/workflows/ruby-gem-publication.yml
+++ b/.github/workflows/ruby-gem-publication.yml
@@ -1,0 +1,12 @@
+name: Ruby Gem Publish
+
+on:
+  push:
+    tags: v*
+
+jobs:
+  call-workflow:
+    uses: zendesk/gw/.github/workflows/ruby-gem-publication.yml@main
+    secrets:
+      RUBY_GEMS_API_KEY: ${{ secrets.RUBY_GEMS_API_KEY }}
+      RUBY_GEMS_TOTP_DEVICE: ${{ secrets.RUBY_GEMS_TOTP_DEVICE }}

--- a/Rakefile
+++ b/Rakefile
@@ -4,4 +4,7 @@ require 'rspec/core/rake_task'
 
 task default: :spec
 
+# Pushing to rubygems is handled by a github workflow
+ENV["gem_push"] = "false"
+
 RSpec::Core::RakeTask.new(:spec)

--- a/lib/property_sets/active_record_extension.rb
+++ b/lib/property_sets/active_record_extension.rb
@@ -126,12 +126,12 @@ module PropertySets
         end
       end
 
-      def save(*args)
-        each { |p| p.save(*args) }
+      def save(...)
+        each { |p| p.save(...) }
       end
 
-      def save!(*args)
-        each { |p| p.save!(*args) }
+      def save!(...)
+        each { |p| p.save!(...) }
       end
 
       def protected?(arg)

--- a/property_sets.gemspec
+++ b/property_sets.gemspec
@@ -8,9 +8,9 @@ Gem::Specification.new "property_sets", PropertySets::VERSION do |s|
   s.homepage = 'http://github.com/zendesk/property_sets'
   s.license  = 'Apache License Version 2.0'
 
-  s.required_ruby_version = ">= 2.4"
+  s.required_ruby_version = ">= 2.7"
 
-  s.add_runtime_dependency("activerecord", ">= 4.2", "< 7.1")
+  s.add_runtime_dependency("activerecord", ">= 5.0", "< 7.1")
   s.add_runtime_dependency("json")
 
   s.add_development_dependency("bump")


### PR DESCRIPTION
Small change to allow *args and **kwargs for save method under ruby3.

Also removed ruby 2.6 and rails 4.2 from the testing matrix (actually the use of the forward args ... operator would prevent ruby 2.6 usage).

Finally added a GHA workflow which automates publishing the Gem to RubyGems when a commit is tagged with something beginning with v. 