### PR TITLE
Add support for models inside modules.

### DIFF
--- a/lib/property_sets.rb
+++ b/lib/property_sets.rb
@@ -9,20 +9,21 @@ end
 
 module PropertySets
   def self.ensure_property_set_class(association, owner_class_name)
-    const_name = "#{owner_class_name}#{association.to_s.singularize.camelcase}".to_sym
+    const_name = "#{owner_class_name.demodulize}#{association.to_s.singularize.camelcase}"
+    namespace = owner_class_name.deconstantize.safe_constantize || Object
 
-    unless Object.const_defined?(const_name)
+    unless namespace.const_defined?(const_name, false)
       property_class = Class.new(ActiveRecord::Base) do
         include PropertySets::PropertySetModel::InstanceMethods
         extend  PropertySets::PropertySetModel::ClassMethods
       end
 
-      Object.const_set(const_name, property_class)
+      namespace.const_set(const_name, property_class)
 
       property_class.owner_class = owner_class_name
       property_class.owner_assoc = association
     end
 
-    Object.const_get(const_name)
+    namespace.const_get(const_name.to_s)
   end
 end

--- a/lib/property_sets/active_record_extension.rb
+++ b/lib/property_sets/active_record_extension.rb
@@ -36,7 +36,7 @@ module PropertySets
           :class_name => property_class.name,
           :autosave => true,
           :dependent => :destroy,
-          :inverse_of => self.name.underscore.to_sym,
+          :inverse_of => self.name.demodulize.underscore.to_sym,
         }.merge(options)
 
         # TODO: should check options are compatible? warn? raise?

--- a/lib/property_sets/property_set_model.rb
+++ b/lib/property_sets/property_set_model.rb
@@ -137,9 +137,10 @@ module PropertySets
       end
 
       def owner_class=(owner_class_name)
-        @owner_class_sym = owner_class_name.underscore.to_sym
-        belongs_to              owner_class_sym
-        validates_presence_of   owner_class_sym
+        @owner_class_sym = owner_class_name.to_s.demodulize.underscore.to_sym
+
+        belongs_to              owner_class_sym, class_name: owner_class_name
+        validates_presence_of   owner_class_sym, class_name: owner_class_name
         validates_uniqueness_of :name, :scope => owner_class_key_sym, :case_sensitive => false
         attr_accessible         owner_class_key_sym, owner_class_sym if defined?(ProtectedAttributes)
       end

--- a/spec/delegator_spec.rb
+++ b/spec/delegator_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe PropertySets::Delegator do
-  let(:account) { Account.create(:name => "Name") }
+  let(:account) { Parent::Account.create(:name => "Name") }
   let(:default) { 'skep' }
 
   describe "read" do

--- a/spec/property_sets_spec.rb
+++ b/spec/property_sets_spec.rb
@@ -7,28 +7,28 @@ PropertySets::PropertySetModel::COLUMN_TYPE_LIMITS =
 $-w = old
 
 describe PropertySets do
-  let(:account) { Account.create(:name => "Name") }
-  let(:relation) { Account.reflections["settings"] }
+  let(:account) { Parent::Account.create(:name => "Name") }
+  let(:relation) { Parent::Account.reflections["settings"] }
 
   it "construct the container class" do
-    expect(defined?(AccountSetting)).to be_truthy
-    expect(defined?(AccountText)).to be_truthy
-    expect(defined?(AccountTypedDatum)).to be_truthy
+    expect(defined?(Parent::AccountSetting)).to be_truthy
+    expect(defined?(Parent::AccountText)).to be_truthy
+    expect(defined?(Parent::AccountTypedDatum)).to be_truthy
   end
 
   it "register the property sets used on a class" do
     %i(settings texts validations typed_data).each do |name|
-      expect(Account.property_set_index).to include(name)
+      expect(Parent::Account.property_set_index).to include(name)
     end
   end
 
   it "sets inverse_of" do
-    expect(relation.inverse_of.klass).to eq Account
+    expect(relation.inverse_of.klass).to eq Parent::Account
   end
 
   it "reopening property_set is idempotent, first one wins on options etc" do
-    expect(Array(relation.options[:extend])).to include Account::Woot
-    expect(account.settings.extensions).to include Account::Woot
+    expect(Array(relation.options[:extend])).to include Parent::Account::Woot
+    expect(account.settings.extensions).to include Parent::Account::Woot
   end
 
   it "allow the owner class to be customized" do
@@ -44,10 +44,10 @@ describe PropertySets do
       self.table_name = "things" # cheat and reuse things table
     end
 
-    AnotherThing.property_set(:settings, :extend => Account::Woot,
+    AnotherThing.property_set(:settings, :extend => Parent::Account::Woot,
                               :table_name => "thing_settings")
 
-    expect(AnotherThing.new.settings.extensions).to include(::Account::Woot)
+    expect(AnotherThing.new.settings.extensions).to include(::Parent::Account::Woot)
   end
 
   it "support protecting attributes" do
@@ -62,7 +62,7 @@ describe PropertySets do
     account.settings.enable(:hep)
     expect(account.settings.hep?).to be true
 
-    account = Account.new
+    account = Parent::Account.new
     expect(account.settings.foo?).to be false
     account.settings.enable(:foo)
     expect(account.settings.foo?).to be true
@@ -111,7 +111,7 @@ describe PropertySets do
   end
 
   it "reject settings with an invalid name" do
-    s = AccountSetting.new(:account => account)
+    s = Parent::AccountSetting.new(:account => account)
 
     valids   = %w(hello hel_lo hell0) + [:hello]
     invalids = %w(_hello)
@@ -161,7 +161,7 @@ describe PropertySets do
   end
 
   it "reference the owner instance when constructing a new record ...on a new record" do
-    account = Account.new(:name => "New")
+    account = Parent::Account.new(:name => "New")
     record  = account.settings.lookup(:baz)
 
     expect(record).to be_new_record
@@ -232,7 +232,7 @@ describe PropertySets do
     end
 
     it "work identically for new and existing owner objects" do
-      [ account, Account.new(:name => "Mibble") ].each do |account|
+      [ account, Parent::Account.new(:name => "Mibble") ].each do |account|
         account.settings.set(:foo => "123", :bar => "456")
 
         expect(account.settings.size).to eq(2)
@@ -368,7 +368,7 @@ describe PropertySets do
     it "creates changed attributes" do
       account.update_attribute(:old, "it works!")
       expect(account.previous_changes["old"].last).to eq("it works!")
-      expect(Account.find(account.id).old).to eq("it works!")
+      expect(Parent::Account.find(account.id).old).to eq("it works!")
     end
 
     it "updates changed attributes for existing property_set data" do
@@ -376,7 +376,7 @@ describe PropertySets do
       account.save
       account.update_attribute(:old, "it works!")
       expect(account.previous_changes["old"].last).to eq("it works!")
-      expect(Account.find(account.id).old).to eq("it works!")
+      expect(Parent::Account.find(account.id).old).to eq("it works!")
     end
 
     it "updates changed attributes for existing property_set data after set through forwarded method" do
@@ -384,7 +384,7 @@ describe PropertySets do
       account.save
       account.update_attribute(:old, "it works!")
       expect(account.previous_changes["old"].last).to eq("it works!")
-      expect(Account.find(account.id).old).to eq("it works!")
+      expect(Parent::Account.find(account.id).old).to eq("it works!")
     end
   end
 

--- a/spec/support/account.rb
+++ b/spec/support/account.rb
@@ -1,58 +1,61 @@
 require_relative 'acts_like_an_integer'
 
-class Account < ActiveRecord::Base
-  include PropertySets::Delegator
-  delegate_to_property_set :settings, :old => :hep
+module Parent
+  class Account < ActiveRecord::Base
+    include PropertySets::Delegator
+    delegate_to_property_set :settings, :old => :hep
 
-  # nonsense module to use in options below, only used as a marker
-  module Woot # doesn't actually seem to be used in AR4 ?
-  end
+    # nonsense module to use in options below, only used as a marker
+    module Woot # doesn't actually seem to be used in AR4 ?
+    end
 
-  property_set :settings, extend: Woot do
-    property :foo
-    property :bar
-    property :baz
-    property :hep, :default   => 'skep'
-    property :pro, :protected => true
-    property :bool_true, :type => :boolean, :default => true
-    property :bool_false, :type => :boolean, :default => false
-    property :bool_nil, :type => :boolean, :default => nil
-  end
+    property_set :settings, extend: Woot do
+      property :foo
+      property :bar
+      property :baz
+      property :hep, :default => 'skep'
+      property :pro, :protected => true
+      property :bool_true, :type => :boolean, :default => true
+      property :bool_false, :type => :boolean, :default => false
+      property :bool_nil, :type => :boolean, :default => nil
+    end
 
-  property_set :settings do # reopening should maintain `extend` above
-    property :bool_nil2, :type => :boolean
-  end
+    property_set :settings do
+      # reopening should maintain `extend` above
+      property :bool_nil2, :type => :boolean
+    end
 
-  property_set :texts do
-    property :foo
-    property :bar
-  end
+    property_set :texts do
+      property :foo
+      property :bar
+    end
 
-  accepts_nested_attributes_for :texts
+    accepts_nested_attributes_for :texts
 
-  property_set :validations do
-    property :validated
-    property :regular
+    property_set :validations do
+      property :validated
+      property :regular
 
-    validates_format_of :value, :with => /\d+/, :message => "BEEP", :if => lambda { |r| r.name.to_sym == :validated }
-  end
+      validates_format_of :value, :with => /\d+/, :message => "BEEP", :if => lambda { |r| r.name.to_sym == :validated }
+    end
 
-  property_set :typed_data do
-    property :string_prop, :type => :string
-    property :datetime_prop, :type => :datetime
-    property :float_prop, :type => :float
-    property :int_prop, :type => :integer
-    property :serialized_prop, :type => :serialized
-    property :default_prop, :type => :integer, :default => ActsLikeAnInteger.new
-    property :serialized_prop_with_default, :type => :serialized, :default => "[]"
-  end
+    property_set :typed_data do
+      property :string_prop, :type => :string
+      property :datetime_prop, :type => :datetime
+      property :float_prop, :type => :float
+      property :int_prop, :type => :integer
+      property :serialized_prop, :type => :serialized
+      property :default_prop, :type => :integer, :default => ActsLikeAnInteger.new
+      property :serialized_prop_with_default, :type => :serialized, :default => "[]"
+    end
 
-  property_set :tiny_texts do
-    property :serialized, :type => :serialized
+    property_set :tiny_texts do
+      property :serialized, :type => :serialized
+    end
   end
 end
 
 module Other
-  class Account < ::Account
+  class Account < ::Parent::Account
   end
 end


### PR DESCRIPTION
At the moment the `property_sets` gem cannot be used within a model that is defined inside a module:

```ruby
# This doesn't work!
module Parent
  class Account < ActiveRecord::Base
    property_set :settings do
      property :foo
    end
  end
end
```

This changes adds this support. I've updated the test suite so the `Account` class that is used throughout the test suite is nested inside the `Parent` module.