### PR TITLE
drop support for active record 5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,6 @@ jobs:
           - rails6.1
           - rails7.0
         include:
-          - {ruby-version: '2.7', gemfile: rails5.0}
-          - {ruby-version: '2.7', gemfile: rails5.1}
-          - {ruby-version: '2.7', gemfile: rails5.2}
           - {ruby-version: '2.7', gemfile: rails6.0}
           - {ruby-version: '3.0', gemfile: rails6.0}
     env:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Property sets [![Build Status](https://github.com/zendesk/property_sets/workflows/CI/badge.svg)](https://github.com/zendesk/property_sets/actions?query=workflow%3ACI)
 
-This gem is a way for you to use a basic "key/value" store for storing attributes for a given model in a relational fashion where there's a row per attribute. Alternatively you'd need to add a new column per attribute to your main table, or serialize the attributes and their values using the [ActiveRecord 3.2 store](https://github.com/rails/rails/commit/85b64f98d100d37b3a232c315daa10fad37dccdc).
+This gem is a way for you to use a basic "key/value" store for storing attributes for a given model in a relational fashion where there's a row per attribute. Alternatively you'd need to add a new column per attribute to your main table, or serialize the attributes and their values using the [Active Record Store](https://api.rubyonrails.org/classes/ActiveRecord/Store.html).
 
 ## Description
 

--- a/gemfiles/common.rb
+++ b/gemfiles/common.rb
@@ -1,3 +1,1 @@
-gem 'iconv', :platforms => [:ruby_20, :ruby_21]
-
-gem "pry-byebug", require:false
+gem "pry-byebug", require: false

--- a/gemfiles/rails5.0.gemfile
+++ b/gemfiles/rails5.0.gemfile
@@ -1,9 +1,0 @@
-source "https://rubygems.org"
-
-gemspec :path=>"../"
-
-gem "activerecord", "~> 5.0.0"
-gem "actionpack", "~> 5.0.0"
-gem "sqlite3", "~> 1.3.6"
-
-eval_gemfile "common.rb"

--- a/gemfiles/rails5.1.gemfile
+++ b/gemfiles/rails5.1.gemfile
@@ -1,9 +1,0 @@
-source 'https://rubygems.org'
-
-gemspec path: '../'
-
-gem 'activerecord', '~> 5.1.3'
-gem 'actionpack', '~> 5.1.3'
-gem "sqlite3", "~> 1.3.6"
-
-eval_gemfile "common.rb"

--- a/gemfiles/rails5.2.gemfile
+++ b/gemfiles/rails5.2.gemfile
@@ -1,9 +1,0 @@
-source 'https://rubygems.org'
-
-gemspec path: '../'
-
-gem 'activerecord', '~> 5.2.0'
-gem 'actionpack', '~> 5.2.0'
-gem "sqlite3", "~> 1.3.6"
-
-eval_gemfile "common.rb"

--- a/lib/property_sets/active_record_extension.rb
+++ b/lib/property_sets/active_record_extension.rb
@@ -5,9 +5,6 @@ require 'set'
 module PropertySets
   module ActiveRecordExtension
     module ClassMethods
-
-      RAILS6 = ActiveRecord::VERSION::MAJOR >= 6
-
       def property_set(association, options = {}, &block)
         unless include?(PropertySets::ActiveRecordExtension::InstanceMethods)
           self.send(:prepend, PropertySets::ActiveRecordExtension::InstanceMethods)
@@ -49,16 +46,10 @@ module PropertySets
           end
         end
 
-        # eg 5: AccountSettingsAssociationExtension
-        # eg 6: Account::SettingsAssociationExtension
-
         # stolen/adapted from AR's collection_association.rb #define_extensions
 
         module_name = "#{association.to_s.camelize}AssociationExtension"
-        module_name = name.demodulize + module_name unless RAILS6
-
-        target = RAILS6 ? self : self.parent
-        association_module = target.const_get module_name
+        association_module = self.const_get module_name
 
         association_module.module_eval do
           include PropertySets::ActiveRecordExtension::AssociationExtensions

--- a/lib/property_sets/delegator.rb
+++ b/lib/property_sets/delegator.rb
@@ -40,7 +40,7 @@ module PropertySets
               send("#{old_attr}_will_change!")
             end
             send(setname).send("#{new_attr}=", value)
-            super(value) if defined?(super) # Rails 4 does not define this
+            super(value)
           end
 
           define_method("#{old_attr}_will_change!") do

--- a/lib/property_sets/delegator.rb
+++ b/lib/property_sets/delegator.rb
@@ -27,11 +27,7 @@ module PropertySets
 
         mappings.each do |old_attr, new_attr|
           self.delegated_property_set_attributes << old_attr.to_s
-          if ActiveRecord.version < Gem::Version.new("5.0")
-            attribute old_attr, ActiveRecord::Type::Value.new
-          else
-            attribute old_attr, ActiveModel::Type::Value.new
-          end
+          attribute old_attr, ActiveModel::Type::Value.new
           define_method(old_attr) {
             association = send(setname)
             type = association.association_class.type(new_attr)

--- a/property_sets.gemspec
+++ b/property_sets.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new "property_sets", PropertySets::VERSION do |s|
 
   s.required_ruby_version = ">= 2.7"
 
-  s.add_runtime_dependency("activerecord", ">= 5.0", "< 7.1")
+  s.add_runtime_dependency("activerecord", ">= 6.0", "< 7.1")
   s.add_runtime_dependency("json")
 
   s.add_development_dependency("bump")

--- a/spec/property_sets_spec.rb
+++ b/spec/property_sets_spec.rb
@@ -407,14 +407,6 @@ describe PropertySets do
       expect(account.previous_changes).to_not include("old")
     end
 
-    if ActiveRecord.version < Gem::Version.new("5.2")
-      it "errors when updating only delegated column names" do
-        expect {
-          account.update_column(:old, "it works!")
-        }.to raise_error(ArgumentError, "Empty list of attributes to change")
-      end
-    end
-
     it "does not prevent other non-delegated property set models from updating" do
       thing = Thing.create(name: 'test')
       expect(thing.update_columns(name: 'it works')).to be


### PR DESCRIPTION
Drops support for Rails 5.0, 5.1, and 5.2 (security support for 5.2 ended last year).