### PR TITLE
inherit property model from the same parent that owner has

### DIFF
--- a/spec/inheritance_spec.rb
+++ b/spec/inheritance_spec.rb
@@ -1,0 +1,38 @@
+require 'active_support'
+require 'active_record'
+require 'property_sets'
+
+ENV["RAILS_ENV"] = "test"
+
+yaml_config = "spec/support/database.yml"
+ActiveRecord::Base.configurations = begin
+                                      YAML.safe_load(IO.read(yaml_config), aliases: true)
+                                    rescue ArgumentError
+                                      YAML.safe_load(IO.read(yaml_config))
+                                    end
+
+class AbstractUnshardedModel < ActiveRecord::Base
+  self.abstract_class = true
+
+  connects_to database: {writing: :unsharded_database, reading: :unsharded_database_replica}
+end
+
+class Vehicle < AbstractUnshardedModel
+  property_set :settings do
+    property :type
+  end
+end
+
+describe PropertySets do
+  it "creates property_set model" do
+    expect(defined?(VehicleSetting)).to be_truthy
+  end
+
+  it "inherits from a correct class" do
+    if ActiveRecord.gem_version >= Gem::Version.new("6.1")
+      expect(VehicleSetting.superclass).to be(AbstractUnshardedModel)
+    else
+      expect(VehicleSetting.superclass).to be(ActiveRecord::Base)
+    end
+  end
+end

--- a/spec/support/database.yml
+++ b/spec/support/database.yml
@@ -1,0 +1,11 @@
+test:
+  unsharded_database:
+    adapter: sqlite3
+    encoding: utf8
+    database: unsharded_database
+
+  unsharded_database_replica:
+    adapter: sqlite3
+    encoding: utf8
+    database: unsharded_database_replica
+    replica: true


### PR DESCRIPTION
Cleaned-up version of https://github.com/zendesk/property_sets/pull/102.

Instead of always inheriting from `ActiveRecord::Base` (which blocks [using multiple databases](https://guides.rubyonrails.org/active_record_multiple_databases.html)), a property model should inherit from the same parent as its owner (and, thus, connect to the same database).