### PR TITLE
Release v3.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.10.0] - 2023-11-08
+
 * Property tables can now live on a separate database to their parent models. This is achieved, on a per-model basis, by configuring the connection class that will be used by property sets. e.g. set `self.property_sets_connection_class = Foo` on the model to instruct `property_sets` to use `Foo`'s database connection when looking for the property sets tables.
 
 ## [3.10.0] - 2023-09-18

--- a/lib/property_sets/version.rb
+++ b/lib/property_sets/version.rb
@@ -1,3 +1,3 @@
 module PropertySets
-  VERSION = "3.10.0"
+  VERSION = "3.11.0"
 end


### PR DESCRIPTION
* Property tables can now live on a separate database to their parent models. This is achieved, on a per-model basis, by configuring the connection class that will be used by property sets. e.g. set `self.property_sets_connection_class = Foo` on the model to instruct `property_sets` to use `Foo`'s database connection when looking for the property sets tables.