### PR TITLE
Use sqlite3 v2.0+ for Rails main

### DIFF
--- a/gemfiles/rails_main.gemfile
+++ b/gemfiles/rails_main.gemfile
@@ -4,6 +4,6 @@ gemspec path: "../"
 
 gem "activerecord", github: "rails/rails", branch: "main"
 gem "actionpack", github: "rails/rails", branch: "main"
-gem "sqlite3", "~> 1.4"
+gem "sqlite3", "~> 2"
 
 eval_gemfile "common.rb"


### PR DESCRIPTION
ActiveRecord now requires sqlite3 >= 2.0[^1].

[^1]:(https://github.com/rails/rails/blob/171c4e4d377d9653a79d38c94bdfadf1a2c4c312/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb#L14)