### PR TITLE
Don't define methods twice for the same keys

### DIFF
--- a/lib/property_sets/active_record_extension.rb
+++ b/lib/property_sets/active_record_extension.rb
@@ -57,6 +57,7 @@ module PropertySets
 
           property_class.keys.each do |key|
             raise "Invalid property key #{key}" if respond_to?(key)
+            next if method_defined?(key) # Methods are already defined for this key
 
             # Reports the coerced truth value of the property
             define_method :"#{key}?" do


### PR DESCRIPTION
When calling `property_set` twice with the same association name, the methods from the first block would be defined twice, resulting in Ruby warnings saying "warning: method redefined". E.g.

    property_set :settings do
      property :foo
    end

    property_set :settings do
      property :bar
    end

in code run with `RUBYOPT="-W2" would result in

    warning: method redefined; discarding old foo?
    warning: previous definition of foo? was here
    warning: method redefined; discarding old foo
    warning: previous definition of foo was here
    warning: method redefined; discarding old foo=
    warning: previous definition of foo= was here
    warning: method redefined; discarding old foo_record
    warning: previous definition of foo_record was here
    warning: method redefined; discarding old property_serialized?
    warning: previous definition of property_serialized? was here